### PR TITLE
Throw error if stack creation failed

### DIFF
--- a/ApplicationServerDeployment/libs/cloud_formation_client.py
+++ b/ApplicationServerDeployment/libs/cloud_formation_client.py
@@ -83,6 +83,8 @@ class CloudFormationClient:
                         Tags=tags,
                         DisableRollback=False
                     )
+                else:
+                    raise e
             stack_id = response.get('StackId', stack_name)
             stack_status = ''
             event_index = 0


### PR DESCRIPTION
*Issue #, if available:*
When user has no permissions to create a stack, original error is masked by the following message:

`
Traceback (most recent call last):
  File "ApplicationServerDeployment\deploy_stack.py", line 69, in <module>
    cf_client.create_stack(
  File "...\amazon-sidewalk-sample-iot-app-main\ApplicationServerDeployment\libs\cloud_formation_client.py", line 86, in create_stack
    stack_id = response.get('StackId', stack_name)
UnboundLocalError: local variable 'response' referenced before assignment
 `


*Description of changes:*
After fix, all errors that occur during the stack creation (except for AlreadyExistsException) will be thrown as well.
After this fix the message is clear:
`
[ERROR]         Terminating: SidewalkSampleApplicationStack creation failed: An error occurred (AccessDenied) when calling the CreateStack operation: User: ... is not authorized to perform: cloudformation:CreateStack on resource: arn:aws:cloudformation:us-east-1:...:stack/SidewalkSampleApplicationStack/* because no identity-based policy allows the cloudformation:CreateStack action.
`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
